### PR TITLE
use --cache-from for more faster build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,9 @@ steps:
   waitFor: ['frontend-npm-build']
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/backend:$BRANCH_NAME', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/backend:$BRANCH_NAME',
+         '--cache-from', 'gcr.io/$PROJECT_ID/backend:latest',
+         '.']
   dir: 'backend'
   waitFor: ['-']
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,13 +25,13 @@ steps:
   args:
   - '-c'
   - |
-    docker pull gcr.io/$PROJECT_ID/backend || exit 0
+    docker pull gcr.io/$PROJECT_ID/backend:master || exit 0
   waitFor: ['-']
   id: 'pull-cache'
 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/backend:$BRANCH_NAME',
-         '--cache-from', 'gcr.io/$PROJECT_ID/backend:latest',
+         '--cache-from', 'gcr.io/$PROJECT_ID/backend:master',
          '.']
   dir: 'backend'
   waitFor: ['pull-cache']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,12 +19,22 @@ steps:
   dir: 'frontend/build'
   waitFor: ['frontend-npm-build']
 
+# https://cloud.google.com/cloud-build/docs/speeding-up-builds?hl=ja#using_a_cached_docker_image
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    docker pull gcr.io/$PROJECT_ID/backend || exit 0
+  waitFor: ['-']
+  id: 'pull-cache'
+
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/backend:$BRANCH_NAME',
          '--cache-from', 'gcr.io/$PROJECT_ID/backend:latest',
          '.']
   dir: 'backend'
-  waitFor: ['-']
+  waitFor: ['pull-cache']
 
 
 images:


### PR DESCRIPTION
This follows https://cloud.google.com/cloud-build/docs/speeding-up-builds?hl=ja#using_a_cached_docker_image